### PR TITLE
Whitelist connection from default private network

### DIFF
--- a/config/rsyncd.conf
+++ b/config/rsyncd.conf
@@ -27,7 +27,7 @@ read only = true
 # Downloads will be possible if file permissions on the daemon side allow them
 write only = false
 
-hosts allow = localhost, get.jenkins.io, mirror.jenkins-ci.org,172.0.0.0/8
+hosts allow = localhost, get.jenkins.io, mirrors.jenkins-ci.org,172.16.0.0/12,10.0.0.0/8,192.168.0.0/16
 
 [jenkins]
 path = /srv/releases/jenkins


### PR DESCRIPTION
Whitelist connection from default private network
Fix typo in mirrors.jenkins-ci.org

Signed-off-by: Olivier Vernin <olivier@vernin.me>