### PR TITLE
Feat: enable periodic rebuild of the image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+hadolint.json
+*.tar

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,1 +1,16 @@
-buildDockerAndPublishImage('rsyncd', [mainBranch: 'main'])
+@Library('pipeline-library@pull/211/head') _
+
+parallel(
+  failFast: true,
+  'docker-image': {
+    buildDockerAndPublishImage('rsyncd', [mainBranch: 'main',])
+  },
+  'updatecli': {
+    withCredentials([string(credentialsId: 'updatecli-github-token', variable: 'UPDATECLI_GITHUB_TOKEN')]) {
+      updatecli(action: 'diff')
+      if (env.BRANCH_NAME == 'main') {
+        updatecli(action: 'apply', cronTriggerExpression: '@daily')
+      }
+    }
+  },
+)

--- a/updatecli/updatecli.d/tini.yml
+++ b/updatecli/updatecli.d/tini.yml
@@ -1,0 +1,41 @@
+---
+title: "Bump tini version"
+sources:
+  getTiniVersion:
+    kind: githubRelease
+    name: Get the latest Tini version
+    spec:
+      owner: "krallin"
+      repository: "tini"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionFilter:
+        kind: latest
+conditions:
+  testDockerfileArgTiniVersion:
+    name: "Does the Dockerfile have an ARG instruction which key is TINI_VERSION?"
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "TINI_VERSION"
+targets:
+  updateDockerfileArgTiniVersion:
+    name: "Update the value of ARG TINI_VERSION in the Dockerfile"
+    sourceID: getTiniVersion
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "TINI_VERSION"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,0 +1,8 @@
+github:
+  user: "updatebot"
+  email: "updatebot@olblak.com"
+  username: "jenkins-infra-bot"
+  token: "UPDATECLI_GITHUB_TOKEN"
+  branch: "main"
+  owner: "jenkins-infra"
+  repository: "docker-rsyncd"


### PR DESCRIPTION
This PR enables a daily rebuild of the image:

- It adds an updatecli configuration to keep `tini` up to date
- It updates the pipeline to run periodically: daily for testing 2-3 times, and we can switch back to weekly once we are sure it works as expected

Depends on #5