### PR TITLE
chore: switch periodic rebuild to weekly

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,5 +1,3 @@
-@Library('pipeline-library@pull/211/head') _
-
 parallel(
   failFast: true,
   'docker-image': {
@@ -9,7 +7,7 @@ parallel(
     withCredentials([string(credentialsId: 'updatecli-github-token', variable: 'UPDATECLI_GITHUB_TOKEN')]) {
       updatecli(action: 'diff')
       if (env.BRANCH_NAME == 'main') {
-        updatecli(action: 'apply', cronTriggerExpression: '@daily')
+        updatecli(action: 'apply', cronTriggerExpression: '@weekly')
       }
     }
   },


### PR DESCRIPTION
Since https://github.com/jenkins-infra/pipeline-library/pull/211 has been tested and merged successfully, we can switch the periodic rebuild to weekly.