### PR TITLE
fix(sshd) only generate host keys if absent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ ARG uid=1000
 ARG gid=1000
 ARG user_home="/home/${user}"
 ENV USER_ETC_DIR="${user_home}/etc"
+ENV HOST_KEYS_DIR="${USER_ETC_DIR}/keys"
 ENV USER_RUN_DIR="${user_home}/run"
 
 RUN groupadd -g ${gid} ${group} \

--- a/cst.yml
+++ b/cst.yml
@@ -18,6 +18,8 @@ metadataTest:
       value: /home/rsyncd/etc
     - key: USER_RUN_DIR
       value: /home/rsyncd/run
+    - key: HOST_KEYS_DIR
+      value: /home/rsyncd/etc/keys
     - key: SSHD_LOG_LEVEL
       value: INFO
   volumes: ["/home/rsyncd", "/tmp"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,13 +13,13 @@ case "${RSYNCD_DAEMON:-rsyncd}" in
     'sshd')
       # We do not want expansion for envsubst argument
       # shellcheck disable=SC2016
-      envsubst '$SSHD_PORT $SSHD_LOG_LEVEL $USER_ETC_DIR $USER_RUN_DIR'< "${USER_ETC_DIR}"/sshd_config.orig > "${USER_ETC_DIR}"/sshd_config
+      envsubst '$SSHD_PORT $SSHD_LOG_LEVEL $USER_ETC_DIR $USER_RUN_DIR $HOST_KEYS_DIR'< "${USER_ETC_DIR}"/sshd_config.orig > "${USER_ETC_DIR}"/sshd_config
 
       # Generate hostkeys if absent
-      test -f "${USER_ETC_DIR}"/ssh_host_dsa_key || ssh-keygen -q -N "" -t dsa -f "${USER_ETC_DIR}"/ssh_host_dsa_key
-      test -f "${USER_ETC_DIR}"/ssh_host_rsa_key || ssh-keygen -q -N "" -t rsa -b 4096 -f "${USER_ETC_DIR}"/ssh_host_rsa_key
-      test -f "${USER_ETC_DIR}"/ssh_host_ecdsa_key || ssh-keygen -q -N "" -t ecdsa -f "${USER_ETC_DIR}"/ssh_host_ecdsa_key
-      test -f "${USER_ETC_DIR}"/ssh_host_ed25519_key || ssh-keygen -q -N "" -t ed25519 -f "${USER_ETC_DIR}"/ssh_host_ed25519_key
+      test -f "${HOST_KEYS_DIR}"/ssh_host_dsa_key || ssh-keygen -q -N "" -t dsa -f "${HOST_KEYS_DIR}"/ssh_host_dsa_key
+      test -f "${HOST_KEYS_DIR}"/ssh_host_rsa_key || ssh-keygen -q -N "" -t rsa -b 4096 -f "${HOST_KEYS_DIR}"/ssh_host_rsa_key
+      test -f "${HOST_KEYS_DIR}"/ssh_host_ecdsa_key || ssh-keygen -q -N "" -t ecdsa -f "${HOST_KEYS_DIR}"/ssh_host_ecdsa_key
+      test -f "${HOST_KEYS_DIR}"/ssh_host_ed25519_key || ssh-keygen -q -N "" -t ed25519 -f "${HOST_KEYS_DIR}"/ssh_host_ed25519_key
 
       # Load public key if provided
       if [[ "${SSHD_PUBLIC_KEY:-'defaultNoKey'}" == ssh-* ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,20 +4,22 @@ set -eux -o pipefail
 
 case "${RSYNCD_DAEMON:-rsyncd}" in
     'rsyncd')
-      # Generate configuration from env vars
+      # We do not want expansion for envsubst argument
+      # shellcheck disable=SC2016
       envsubst '$RSYNCD_PORT $USER_ETC_DIR $USER_RUN_DIR'< "${USER_ETC_DIR}"/rsyncd.conf.orig > "${USER_ETC_DIR}"/rsyncd.conf
       cat "${USER_ETC_DIR}"/rsyncd.conf
       # Start rsyncd daemon
       exec /usr/bin/rsync --no-detach --daemon --config "${USER_ETC_DIR}"/rsyncd.conf;;
     'sshd')
-      # Generate configuration from env vars
+      # We do not want expansion for envsubst argument
+      # shellcheck disable=SC2016
       envsubst '$SSHD_PORT $SSHD_LOG_LEVEL $USER_ETC_DIR $USER_RUN_DIR'< "${USER_ETC_DIR}"/sshd_config.orig > "${USER_ETC_DIR}"/sshd_config
 
-      # Generate hostkeys
-      ssh-keygen -q -N "" -t dsa -f "${USER_ETC_DIR}"/ssh_host_dsa_key
-      ssh-keygen -q -N "" -t rsa -b 4096 -f "${USER_ETC_DIR}"/ssh_host_rsa_key
-      ssh-keygen -q -N "" -t ecdsa -f "${USER_ETC_DIR}"/ssh_host_ecdsa_key
-      ssh-keygen -q -N "" -t ed25519 -f "${USER_ETC_DIR}"/ssh_host_ed25519_key
+      # Generate hostkeys if absent
+      test -f "${USER_ETC_DIR}"/ssh_host_dsa_key || ssh-keygen -q -N "" -t dsa -f "${USER_ETC_DIR}"/ssh_host_dsa_key
+      test -f "${USER_ETC_DIR}"/ssh_host_rsa_key || ssh-keygen -q -N "" -t rsa -b 4096 -f "${USER_ETC_DIR}"/ssh_host_rsa_key
+      test -f "${USER_ETC_DIR}"/ssh_host_ecdsa_key || ssh-keygen -q -N "" -t ecdsa -f "${USER_ETC_DIR}"/ssh_host_ecdsa_key
+      test -f "${USER_ETC_DIR}"/ssh_host_ed25519_key || ssh-keygen -q -N "" -t ed25519 -f "${USER_ETC_DIR}"/ssh_host_ed25519_key
 
       # Load public key if provided
       if [[ "${SSHD_PUBLIC_KEY:-'defaultNoKey'}" == ssh-* ]]; then

--- a/sshd_config
+++ b/sshd_config
@@ -1,9 +1,9 @@
 ## Use a non-privileged port
 Port ${SSHD_PORT}
 ## provide the new path containing these host keys
-HostKey "${USER_ETC_DIR}"/ssh_host_rsa_key
-HostKey "${USER_ETC_DIR}"/ssh_host_ecdsa_key
-HostKey "${USER_ETC_DIR}"/ssh_host_ed25519_key
+HostKey ${HOST_KEYS_DIR}/ssh_host_rsa_key
+HostKey ${HOST_KEYS_DIR}/ssh_host_ecdsa_key
+HostKey ${HOST_KEYS_DIR}/ssh_host_ed25519_key
 LogLevel ${SSHD_LOG_LEVEL}
 ## Provide a path to store PID file which is accessible by normal user for write purpose
 PidFile "${USER_RUN_DIR}"/sshd.pid


### PR DESCRIPTION
The goal is to support cases where we keep constant host keys across container restarts